### PR TITLE
Add reusable docs build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,18 @@
+name: Docs Build
+
+on:
+  push:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-build.yml"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-build.yml"
+
+jobs:
+  build:
+    name: Reusable Docs Build
+    uses: FlowPay/ci-templates/.github/workflows/backend-docs.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `docs-build.yml`
- reuse central CI workflow `FlowPay/ci-templates/.github/workflows/backend-docs.yml@main`
- trigger on push/pull_request for any branch (with docs/workflow path filters)

## Why
Align this repository docs pipeline with FlowPay reusable CI templates and keep docs HTML rendering centralized via `build-docs`.
