### PR TITLE
docs(openapi): 📝  align locked payment docs + clarify openbanking paymentMethod payload 

### DIFF
--- a/docs/checkout.md
+++ b/docs/checkout.md
@@ -22,7 +22,7 @@ If `callbackUrl` is provided, FlowPay sends server-to-server notifications when 
 
 - Method: POST
 - Headers: `Content-Type: application/json`
-- Payload: includes `requestId`, optional `sessionId`, `status`, and timestamps.
+- Payload: includes `requestId`, optional `sessionId`, `status`, and timestamps. For locked payments, the payload may also include a `paymentMethod` object whose `id` is the technical token to use for early release.
 
 Note: ensure idempotency on your endpoint; the same event may be retried.
 

--- a/docs/payment_request.md
+++ b/docs/payment_request.md
@@ -25,7 +25,7 @@ Each of these services uses the FlowPay technical account, but the payment retai
 
 If the lockedUntil field is used, the sum will be kept until the date is reached. Until then the client is able to issue a refund of this payment by using the "Refunds" endpoint, or unlock the payment earlier using the "Charge" endpoint.
 
-When a request to pay is locked a paymentMethod is returned that can be used on the "Charge" endpoint, to unlock the payment. When unlocking the payment no other field is necessary but a validation will be carried on in order to mantain data integrity.
+When a request to pay is locked, the `GET /payment-requests/{requestId}` response includes `lockedDetails.lockedPaymentMethod.id`, which can be used as `tokenId` on the "Charge" endpoint to unlock the payment. The webhook payload also exposes the same technical method as `paymentMethod.id`.
 
 ## Bulk Payment
 

--- a/docs/payment_webhook.md
+++ b/docs/payment_webhook.md
@@ -6,13 +6,13 @@ FlowPay delivers real-time, server-to-server notifications whenever a payment re
 
 There is a single, stable event for Request-to-Pay: `payment.status_change`. The current state is provided in the `status` field and reuses the API enum `PaymentRequestStatus` (`created`, `inProgress`, `authorized`, `rejected`, `onHold`, `locked`, `forwarded`, `refunded`, `deleted`). If the change originates from a specific checkout attempt, the event includes a `sessionId`. Multiple attempts may occur during a request’s lifecycle, and events may be delivered more than once; your handler must therefore be idempotent and tolerant of out-of-order delivery within the same `requestId`.
 
-For locked payments, deliveries may also include an optional `lockedDetails` object. When present, it contains the locked-payment metadata needed to continue the flow, such as reconciliation status, automatic-release state, and the dedicated technical payment method to use for an early release.
+For locked payments, deliveries may also include an optional `paymentMethod` object inside the payload. When present, it identifies the dedicated technical payment method created for the locked flow; its `id` is the value to use as `tokenId` for an early release through `POST /charges`.
 
 ## Request Details
 
 Deliveries use HTTPS POST with a JSON payload encoded in UTF‑8. The request carries headers that establish identity, integrity and replay protection. In particular, `X-FlowPay-Event-Id` uniquely identifies the delivery, `X-FlowPay-Event-Type` is always `payment.status_change`, `X-FlowPay-Timestamp` contains Unix epoch seconds, `X-FlowPay-Signature` holds a detached Ed25519 signature, `X-FlowPay-Key-Id` identifies the public key to use for verification, and `X-FlowPay-Retry-Count` indicates the attempt number starting at zero. Any HTTP 2xx response acknowledges the event.
 
-In locked flows, treat `lockedDetails` as optional enrichment: use it when available, but always be prepared to recover the authoritative state with `GET /payment-requests/{requestId}`.
+In locked flows, treat the webhook `paymentMethod` as optional enrichment: use it when available, but always be prepared to recover the authoritative state with `GET /payment-requests/{requestId}`, which exposes `lockedDetails.lockedPaymentMethod.id`.
 
 ## Security and Verification
 

--- a/docs/request_to_pay.md
+++ b/docs/request_to_pay.md
@@ -292,7 +292,7 @@ Notes:
 
 ### How to enable Locked payment
 
-Add `lockedUntil` (ISO 8601). After reconciliation, use `GET /payment-requests/{requestId}` or the webhook payload to retrieve `lockedDetails.lockedPaymentMethod.id`. Before expiry, either release the funds with `POST /charges` or refund the payer with `POST /refunds`.
+Add `lockedUntil` (ISO 8601). After reconciliation, use `GET /payment-requests/{requestId}` to retrieve `lockedDetails.lockedPaymentMethod.id`. The webhook payload exposes the same technical method as `payload.paymentMethod.id`. Before expiry, either release the funds with `POST /charges` or refund the payer with `POST /refunds`.
 
 ```bash
 BASE_URL="https://api.sandbox.flowpay.it/v2/"

--- a/openapi.json
+++ b/openapi.json
@@ -3389,6 +3389,7 @@
             "OpenbankingTechnology": {
                 "type": "object",
                 "title": "Bank account payload",
+                "description": "Openbanking request payload. `bank` and `instant` are independent optional fields, so clients can send only the data they have available. `instant` defaults to `true` when omitted.",
                 "properties": {
                     "iban": {
                         "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -2717,9 +2717,27 @@
                                                 "$ref": "#/components/schemas/PaymentRequestStatus",
                                                 "description": "Previous status, when available."
                                             },
-                                            "lockedDetails": {
-                                                "$ref": "#/components/schemas/LockedPaymentDetails",
-                                                "description": "Locked-payment metadata, present when the request is in or near the locked lifecycle phase."
+                                            "paymentMethod": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string",
+                                                        "format": "uuid",
+                                                        "description": "Identifier of the dedicated locked payment method. Use this value as `tokenId` on `POST /charges` for an early release."
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "locked"
+                                                        ],
+                                                        "description": "Always `locked` for the technical method emitted in locked payment webhooks."
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "type"
+                                                ],
+                                                "description": "Dedicated technical payment method emitted for locked flows when available."
                                             }
                                         },
                                         "required": [
@@ -3952,14 +3970,6 @@
                         ],
                         "description": "Status of the incoming collection reconciliation."
                     },
-                    "payoutReadiness": {
-                        "type": "string",
-                        "enum": [
-                            "ready",
-                            "beneficiaryPayoutMissing"
-                        ],
-                        "description": "Whether the final payout coordinates are already available for release."
-                    },
                     "automaticRelease": {
                         "$ref": "#/components/schemas/AutomaticRelease"
                     },
@@ -3970,7 +3980,6 @@
                 "required": [
                     "fundsOwner",
                     "reconciliationStatus",
-                    "payoutReadiness",
                     "automaticRelease"
                 ]
             },


### PR DESCRIPTION
- Document that bank and instant are independent optional fields.
- Keep the public OpenAPI aligned with the updated payment request behavior.