### PR TITLE
FPY-1174

### DIFF
--- a/docs/payment_request.md
+++ b/docs/payment_request.md
@@ -23,16 +23,14 @@ Each of these services uses the FlowPay technical account, but the payment retai
 
 ## Filtering Payment Requests
 
-`GET /payment-requests` supports creation-date and lifecycle-status filters. Like the other list date filters, `dateFrom` and `dateTo` use ISO 8601 date-time strings (for example, `2026-07-01T00:00:00Z`). The bounds are inclusive, apply to `createdAt`, and can be used independently. Unix timestamps are not supported. `status` is evaluated against the effective state of the most recently updated payment session. A request without sessions is treated as `created`; an expired `inProgress` session is treated as `deleted`, consistently with the status returned in the response.
+`GET /payment-requests` supports creation-date filters. Like the other list date filters, `dateFrom` and `dateTo` use ISO 8601 date-time strings (for example, `2026-07-01T00:00:00Z`). The bounds are inclusive, apply to `createdAt`, and can be used independently. Unix timestamps are not supported. Lifecycle status filtering belongs to payment-session lists and is not supported on payment requests.
 
-The supported status values are `created`, `inProgress`, `authorized`, `rejected`, `onHold`, `locked`, `forwarded`, `refunded`, and `deleted`.
-
-Example: list payment requests created during July 2026 whose latest status is `authorized`:
+Example: list payment requests created during July 2026:
 
 ```bash
 curl -sS \
   -H "X-API-Key: $API_KEY" \
-  "$BASE_URL/payment-requests?dateFrom=2026-07-01T00:00:00Z&dateTo=2026-07-31T23:59:59Z&status=authorized&limit=20&offset=0"
+  "$BASE_URL/payment-requests?dateFrom=2026-07-01T00:00:00Z&dateTo=2026-07-31T23:59:59Z&limit=20&offset=0"
 ```
 
 If `dateFrom` or `dateTo` is not a valid ISO 8601 date-time, or if `dateFrom` is later than `dateTo`, the API returns `400 Bad Request`.

--- a/docs/payment_request.md
+++ b/docs/payment_request.md
@@ -21,6 +21,22 @@ In addition, FlowPay extends traditional payment methods by providing value-adde
 
 Each of these services uses the FlowPay technical account, but the payment retains the original payer and payee information.
 
+## Filtering Payment Requests
+
+`GET /payment-requests` supports creation-date and lifecycle-status filters. `dateFrom` and `dateTo` are inclusive ISO 8601 timestamps applied to `createdAt`; either bound can be used on its own. `status` is evaluated against the effective state of the most recently updated payment session. A request without sessions is treated as `created`; an expired `inProgress` session is treated as `deleted`, consistently with the status returned in the response.
+
+The supported status values are `created`, `inProgress`, `authorized`, `rejected`, `onHold`, `locked`, `forwarded`, `refunded`, and `deleted`.
+
+Example: list payment requests created during July 2026 whose latest status is `authorized`:
+
+```bash
+curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  "$BASE_URL/payment-requests?dateFrom=2026-07-01T00:00:00Z&dateTo=2026-07-31T23:59:59Z&status=authorized&limit=20&offset=0"
+```
+
+If `dateFrom` or `dateTo` is not a valid ISO 8601 timestamp, or if `dateFrom` is later than `dateTo`, the API returns `400 Bad Request`.
+
 ## Locked Payment
 
 If the lockedUntil field is used, the sum will be kept until the date is reached. Until then the client is able to issue a refund of this payment by using the "Refunds" endpoint, or unlock the payment earlier using the "Charge" endpoint.

--- a/docs/payment_request.md
+++ b/docs/payment_request.md
@@ -23,7 +23,7 @@ Each of these services uses the FlowPay technical account, but the payment retai
 
 ## Filtering Payment Requests
 
-`GET /payment-requests` supports creation-date and lifecycle-status filters. `dateFrom` and `dateTo` are inclusive ISO 8601 timestamps applied to `createdAt`; either bound can be used on its own. `status` is evaluated against the effective state of the most recently updated payment session. A request without sessions is treated as `created`; an expired `inProgress` session is treated as `deleted`, consistently with the status returned in the response.
+`GET /payment-requests` supports creation-date and lifecycle-status filters. Like the other list date filters, `dateFrom` and `dateTo` use ISO 8601 date-time strings (for example, `2026-07-01T00:00:00Z`). The bounds are inclusive, apply to `createdAt`, and can be used independently. Unix timestamps are not supported. `status` is evaluated against the effective state of the most recently updated payment session. A request without sessions is treated as `created`; an expired `inProgress` session is treated as `deleted`, consistently with the status returned in the response.
 
 The supported status values are `created`, `inProgress`, `authorized`, `rejected`, `onHold`, `locked`, `forwarded`, `refunded`, and `deleted`.
 
@@ -35,7 +35,7 @@ curl -sS \
   "$BASE_URL/payment-requests?dateFrom=2026-07-01T00:00:00Z&dateTo=2026-07-31T23:59:59Z&status=authorized&limit=20&offset=0"
 ```
 
-If `dateFrom` or `dateTo` is not a valid ISO 8601 timestamp, or if `dateFrom` is later than `dateTo`, the API returns `400 Bad Request`.
+If `dateFrom` or `dateTo` is not a valid ISO 8601 date-time, or if `dateFrom` is later than `dateTo`, the API returns `400 Bad Request`.
 
 ## Locked Payment
 

--- a/openapi.json
+++ b/openapi.json
@@ -808,7 +808,7 @@
         "/payment-requests": {
             "get": {
                 "summary": "List all created payment requests",
-                "description": "Returns a paginated list of created payment requests. Filters can be combined. `dateFrom` and `dateTo` apply to the request creation timestamp using inclusive bounds; `status` is evaluated against the effective state of the most recently updated payment session.",
+                "description": "Returns a paginated list of created payment requests. `dateFrom` and `dateTo` can be combined and apply to the request creation timestamp using inclusive bounds. Lifecycle status filtering belongs to payment-session lists and is not supported here.",
                 "operationId": "listPaymentRequests",
                 "tags": [
                     "Request To Pay"
@@ -856,15 +856,6 @@
                         },
                         "example": "2026-07-31T23:59:59Z",
                         "description": "Inclusive upper bound for the payment request `createdAt`, encoded as an ISO 8601 date-time (for example, `2026-07-31T23:59:59Z`). Unix timestamps are not supported. Must be greater than or equal to `dateFrom` when both are provided."
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "schema": {
-                            "$ref": "#/components/schemas/PaymentRequestStatus"
-                        },
-                        "example": "authorized",
-                        "description": "Returns requests whose most recently updated payment session has this effective state. A request without sessions is treated as `created`."
                     }
                 ],
                 "responses": {

--- a/openapi.json
+++ b/openapi.json
@@ -808,7 +808,7 @@
         "/payment-requests": {
             "get": {
                 "summary": "List all created payment requests",
-                "description": "Returns a paginated list of all created payment requests.",
+                "description": "Returns a paginated list of created payment requests. Filters can be combined. `dateFrom` and `dateTo` apply to the request creation timestamp using inclusive bounds; `status` is evaluated against the effective state of the most recently updated payment session.",
                 "operationId": "listPaymentRequests",
                 "tags": [
                     "Request To Pay"
@@ -836,6 +836,35 @@
                             "default": 0
                         },
                         "description": "Number of items to skip."
+                    },
+                    {
+                        "name": "dateFrom",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "example": "2026-07-01T00:00:00Z",
+                        "description": "Inclusive lower bound for the payment request `createdAt` timestamp, encoded as ISO 8601."
+                    },
+                    {
+                        "name": "dateTo",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "example": "2026-07-31T23:59:59Z",
+                        "description": "Inclusive upper bound for the payment request `createdAt` timestamp, encoded as ISO 8601. Must be greater than or equal to `dateFrom` when both are provided."
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/PaymentRequestStatus"
+                        },
+                        "example": "authorized",
+                        "description": "Returns requests whose most recently updated payment session has this effective state. A request without sessions is treated as `created`."
                     }
                 ],
                 "responses": {

--- a/openapi.json
+++ b/openapi.json
@@ -845,7 +845,7 @@
                             "format": "date-time"
                         },
                         "example": "2026-07-01T00:00:00Z",
-                        "description": "Inclusive lower bound for the payment request `createdAt` timestamp, encoded as ISO 8601."
+                        "description": "Inclusive lower bound for the payment request `createdAt`, encoded as an ISO 8601 date-time (for example, `2026-07-01T00:00:00Z`). Unix timestamps are not supported."
                     },
                     {
                         "name": "dateTo",
@@ -855,7 +855,7 @@
                             "format": "date-time"
                         },
                         "example": "2026-07-31T23:59:59Z",
-                        "description": "Inclusive upper bound for the payment request `createdAt` timestamp, encoded as ISO 8601. Must be greater than or equal to `dateFrom` when both are provided."
+                        "description": "Inclusive upper bound for the payment request `createdAt`, encoded as an ISO 8601 date-time (for example, `2026-07-31T23:59:59Z`). Unix timestamps are not supported. Must be greater than or equal to `dateFrom` when both are provided."
                     },
                     {
                         "name": "status",
@@ -2327,7 +2327,8 @@
                         "name": "createdFrom",
                         "in": "query",
                         "required": false,
-                        "description": "Lower bound (inclusive) for `createdAt` in ISO 8601.",
+                        "description": "Lower bound (inclusive) for `createdAt`, encoded as an ISO 8601 date-time. Unix timestamps are not supported.",
+                        "example": "2026-07-01T00:00:00Z",
                         "schema": {
                             "type": "string",
                             "format": "date-time"
@@ -2337,7 +2338,8 @@
                         "name": "createdTo",
                         "in": "query",
                         "required": false,
-                        "description": "Upper bound (inclusive) for `createdAt` in ISO 8601.",
+                        "description": "Upper bound (inclusive) for `createdAt`, encoded as an ISO 8601 date-time. Unix timestamps are not supported.",
+                        "example": "2026-07-31T23:59:59Z",
                         "schema": {
                             "type": "string",
                             "format": "date-time"


### PR DESCRIPTION
## Cosa cambia

- documenta dateFrom e dateTo come limiti inclusivi ISO 8601 su createdAt
- documenta un solo formato e specifica che i timestamp Unix non sono supportati
- rimuove status dai parametri della lista Payment Request
- chiarisce che il filtro di stato verrà gestito sulle liste PaymentSession
- aggiorna guida Request To Pay, esempio curl e risposta 400

## Perché

Completa la documentazione pubblica v2s richiesta da [FPY-1174](https://youtrack.flowpay.it/issue/FPY-1174/) mantenendo il contratto coerente con gateway.client e payment.engine.

## Impatto

I consumer possono filtrare per data usando una specifica OpenAPI validata e un esempio operativo, senza ambiguità fra timestamp e ISO 8601.

## Verifiche

- jq empty openapi.json
- Redocly lint: specifica valida; resta il warning preesistente sulla proprietà theme
- E2E gateway-first: PASS
- [report E2E con richieste, risposte e snapshot DB](https://github.com/FlowPay/gateway.client/blob/ad0f71a5ddcf31526c91c51953f19215941c9b1f/docs/tests/FPY-1174/report.md)

## Tracciamento test versionato — esperimento

Il versionamento dei risultati in `docs/tests/FPY-1174` è un esperimento per provare a lasciare traccia dei test effettuati direttamente nella PR e nel task. Questa modalità verrà valutata prima di considerarla una convenzione stabile.